### PR TITLE
Add overlay_filter param to hero headers

### DIFF
--- a/_includes/page__hero.html
+++ b/_includes/page__hero.html
@@ -18,8 +18,14 @@
   {% capture overlay_img_path %}{{ page.header.overlay_image | prepend: "/images/" | prepend: base_path }}{% endcapture %}
 {% endif %}
 
+{% if page.header.overlay_filter contains "rgba" %}
+  {% capture overlay_filter %}{{ page.header.overlay_filter }}{% endcapture %}
+{% elsif page.header.overlay_filter %}
+  {% capture overlay_filter %}rgba(0, 0, 0, {{ page.header.overlay_filter }}){% endcapture %}
+{% endif %}
+
 <div class="page__hero{% if page.header.overlay_color or page.header.overlay_image %}--overlay{% endif %}"
-  style="{% if page.header.overlay_color %}background-color: {{ page.header.overlay_color | default: 'transparent' }};{% endif %} {% if overlay_img_path %}background-image: url('{{ overlay_img_path }}');{% endif %}"
+  style="{% if page.header.overlay_color %}background-color: {{ page.header.overlay_color | default: 'transparent' }};{% endif %} {% if overlay_img_path %}background-image: {% if overlay_filter %}linear-gradient({{overlay_filter}}, {{overlay_filter}}), {% endif %}url('{{ overlay_img_path }}');{% endif %}"
 >
   {% if page.header.overlay_color or page.header.overlay_image %}
     <div class="wrapper">


### PR DESCRIPTION
The `overlay_filter` param lets you darken or otherwise filter the hero header picture to make the text content pop out more.

You can use it by specifying the opacity (between 0 and 1) of a black overlay like so:

``` yaml
excerpt: "This post should [...]"
header:
  overlay_image: unsplash-image-1.jpg
  overlay_filter: 0.5 # same as adding an opacity of 0.5 to a black background
  caption: "Photo credit: [**Unsplash**](https://unsplash.com)"
  cta_label: "More Info"
  cta_url: "https://unsplash.com"
```

![05](https://cloud.githubusercontent.com/assets/3392/14953919/59ef65e0-106e-11e6-85f0-0fb985c1c6cc.jpg)

Or if you want to do more fancy things, go full rgba: 

``` yaml
excerpt: "This post should [...]"
header:
  overlay_image: unsplash-image-1.jpg
  overlay_filter: rgba(255, 0, 0, 0.5)
  caption: "Photo credit: [**Unsplash**](https://unsplash.com)"
  cta_label: "More Info"
  cta_url: "https://unsplash.com"
```

![05red](https://cloud.githubusercontent.com/assets/3392/14953922/63be72dc-106e-11e6-8b15-cfa44b8413e5.jpg)
